### PR TITLE
docs: clarification that data can be entered as key value pairs under appropriate conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
 |url     | Request URL   | _required_ Field |
 |method  | Request Method| POST |
 |contentType  | Request ContentType| application/json |
-|data    | Request Body Content as JSON String, only for POST / PUT / PATCH Requests | '{}' |
+|data    | Request Body Content as JSON String (or key=value pairs separated by '&' for form-urlencoded content), only for POST / PUT / PATCH Requests | '{}' |
 |files    | Map of key / absolute file paths send as multipart/form-data request to the API, if set the contentType is set to multipart/form-data, values provided by data will be added as additional FormData values, nested objects are not supported. **Example provided in the _test_ Workflow of this Action** | '{}' |
 |timeout| Request Timeout in ms | 5000 (5s) |
 |username| Username for Basic Auth ||


### PR DESCRIPTION
Hi @fjogeleit and crew!  The way the documentation is currently written, I read it as "data can only be passed as JSON".  I realized after a while that I could in fact use key/value pairs for the `application/x-www-form-urlencoded` content type.

Cheers