### PR TITLE
Adding ability to return headers without setting debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Deploy Stage
-      uses: boro2g/http-request-action@v1
+      uses: boro2g/http-request-action@v1.0.2
       with:
         url: 'https://ansible.io/api/v2/job_templates/84/launch/'
         method: 'POST'
@@ -56,7 +56,7 @@ To display HTTP response data in the GitHub Actions log give the request an `id`
 steps:
   - name: Make Request
     id: myRequest
-    uses: boro2g/http-request-action@v1
+    uses: boro2g/http-request-action@v1.0.2
     with:
       url: "http://yoursite.com/api"
   - name: Show Response

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ To display HTTP response data in the GitHub Actions log give the request an `id`
 steps:
   - name: Make Request
     id: myRequest
-    uses: fjogeleit/http-request-action@v1
+    uses: boro2g/http-request-action@v1
     with:
       url: "http://yoursite.com/api"
   - name: Show Response
     run: |
       echo ${{ steps.myRequest.outputs.response }}
+      echo ${{ steps.myRequest.outputs.headers }}
       echo ${{ fromJson(steps.myRequest.outputs.response).field_you_want_to_access }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
 | Variable |  Description  |
 |---|---|
 `response` | Response as JSON String
-`headers` | Headers as JSON String
+`headers` | Headers
 
 To display HTTP response data in the GitHub Actions log give the request an `id` and access its `outputs`. You can also access specific field from the response data using [fromJson()](https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson) expression.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Deploy Stage
-      uses: fjogeleit/http-request-action@v1
+      uses: boro2g/http-request-action@v1
       with:
         url: 'https://ansible.io/api/v2/job_templates/84/launch/'
         method: 'POST'
@@ -48,6 +48,7 @@ jobs:
 | Variable |  Description  |
 |---|---|
 `response` | Response as JSON String
+`headers` | Headers as JSON String
 
 To display HTTP response data in the GitHub Actions log give the request an `id` and access its `outputs`. You can also access specific field from the response data using [fromJson()](https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson) expression.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Deploy Stage
-      uses: boro2g/http-request-action@v1.0.2
+      uses: fjogeleit/http-request-action@v1
       with:
         url: 'https://ansible.io/api/v2/job_templates/84/launch/'
         method: 'POST'
@@ -56,7 +56,7 @@ To display HTTP response data in the GitHub Actions log give the request an `id`
 steps:
   - name: Make Request
     id: myRequest
-    uses: boro2g/http-request-action@v1.0.2
+    uses: fjogeleit/http-request-action@v1
     with:
       url: "http://yoursite.com/api"
   - name: Show Response

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'HTTP Request Action with Headers'
+name: 'HTTP Request Action'
 description: 'Create any HTTP Request'
 inputs:
     url:

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,8 @@ inputs:
 outputs:
     response:
         description: 'HTTP Response Content'
+    headers:
+        description: 'HTTP Response Headers'
 runs:
     using: 'node16'
     main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'HTTP Request Action'
+name: 'HTTP Request Action with Headers'
 description: 'Create any HTTP Request'
 inputs:
     url:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1968,6 +1968,8 @@ const request = async({ method, instanceConfig, data, files, file, actions, igno
     const response = await instance.request(requestData)
 
     actions.setOutput('response', JSON.stringify(response.data))
+    
+    actions.setOutput('headers', response.headers)
   } catch (error) {
     if ((typeof error === 'object') && (error.isAxiosError === true)) {
       const { name, message, code, response } = error

--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -67,9 +67,9 @@ const request = async({ method, instanceConfig, data, files, file, actions, igno
 
     const response = await instance.request(requestData)
 
-    actions.setOutput('response', JSON.stringify(response.data))
+    //actions.setOutput('response', JSON.stringify(response.data))
     
-    actions.setOutput('headers', JSON.stringify(response.headers))
+    actions.setOutput('headers', response.headers)
   } catch (error) {
     if ((typeof error === 'object') && (error.isAxiosError === true)) {
       const { name, message, code, response } = error

--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -67,7 +67,7 @@ const request = async({ method, instanceConfig, data, files, file, actions, igno
 
     const response = await instance.request(requestData)
 
-    //actions.setOutput('response', JSON.stringify(response.data))
+    actions.setOutput('response', JSON.stringify(response.data))
     
     actions.setOutput('headers', response.headers)
   } catch (error) {

--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -68,6 +68,8 @@ const request = async({ method, instanceConfig, data, files, file, actions, igno
     const response = await instance.request(requestData)
 
     actions.setOutput('response', JSON.stringify(response.data))
+    
+    actions.setOutput('headers', JSON.stringify(response.headers))
   } catch (error) {
     if ((typeof error === 'object') && (error.isAxiosError === true)) {
       const { name, message, code, response } = error


### PR DESCRIPTION
We're using a shared environment where we can't enabled debug mode across all actions. This change means we can still read the response headers, even targeting specific values if needs be via `fromJson(steps.myRequest.outputs.headers).specificHeaderName`