### PR TITLE
add build-action

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -1,0 +1,35 @@
+name: Build Action
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: The branch
+        type: string
+        default: main
+        required: true
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+    - name: Install dependencies
+      run: |
+        npm ci
+    - name: Build Action
+      run: |
+        npm run build
+    - name: Update dist
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git add ./dist &&
+        git commit -m "Update dist"
+        git push origin HEAD:${{ inputs.ref }}


### PR DESCRIPTION
This PR adds an action to rebuild the action in the dist folder. Useful if you want to do "npm run build" and commit directly to a branch per workflow dispatch.