### PR TITLE
docs: fix inaccuracies and document missing outputs in action.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ jobs:
 |---|---|
 `response` | Response as JSON String
 `headers` | Headers
-`status` | HTTP status message
+`status` | HTTP Response Status Code
+`requestError` | On request failure, a JSON string with fields: `name`, `message`, `code`, `status`
 
 To display HTTP response data in the GitHub Actions log give the request an `id` and access its `outputs`. You can also access specific field from the response data using [fromJson()](https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson) expression.
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
         required: false
         default: '{}'
     file:
-        description: 'A single absolute file path, sent as application/octet-stream. Only used when data and files are both empty.'
+        description: 'A single absolute file path. Only used when data and files are both empty.'
         required: false
     username:
         description: 'Auth Username'

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ outputs:
     status:
         description: 'HTTP Response Status Code'
     requestError:
-        description: 'On request failure, a JSON string with fields: name, message, code, status'
+        description: 'On Axios request errors, a JSON string with fields: name, message, code, status; status may be null when no response is available'
 runs:
     using: 'node24'
     main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -11,16 +11,17 @@ inputs:
     contentType:
         description: 'Content Type'
         required: false
+        default: 'application/json'
     data:
         description: 'Request Body as JSON String'
         required: false
         default: '{}'
     files:
-        description: 'Map of absolute file paths as JSON String'
+        description: 'Multipart form-data file map as a JSON string, e.g. {"fieldName": "/absolute/path/to/file"}. Takes precedence over file when both are set.'
         required: false
         default: '{}'
     file:
-        description: 'A single absolute file path'
+        description: 'A single absolute file path, sent as application/octet-stream. Only used when data and files are both empty.'
         required: false
     username:
         description: 'Auth Username'
@@ -36,17 +37,19 @@ inputs:
         description: 'Bearer Authentication Token'
         required: false
     customHeaders:
-        description: 'Custom HTTP Headers'
+        description: 'Custom HTTP Headers as a JSON object string, e.g. {"Header-Name": "value"}'
         required: false
     preventFailureOnNoResponse:
-        description: 'Prevent this Action to fail if the request respond without an response'
+        description: "Prevent this Action from failing if the request receives no response. Set to 'true' to enable."
         required: false
+        default: 'false'
     ignoreStatusCodes:
-        description: 'Prevent this Action to fail if the request respond with one of the configured StatusCodes'
+        description: 'Comma-separated list of HTTP status codes that will not cause the action to fail, e.g. "404,422"'
         required: false
     escapeData:
         description: 'Escape newlines in data string content'
         required: false
+        default: 'false'
     httpsCA:
         description: 'Certificate authority as string in PEM format'
         required: false
@@ -64,21 +67,26 @@ inputs:
         required: false
         default: 'false'
     retry:
-        description: 'optional amount of retries if the request fails'
+        description: 'Number of retries if the request fails'
         required: false
+        default: '0'
     retryWait:
-        description: 'wait time between retries in milliseconds'
+        description: 'Wait time between retries in milliseconds'
         required: false
+        default: '3000'
     ignoreSsl:
-        description: 'ignore ssl verify (rejectUnauthorized: false)'
+        description: 'Ignore SSL verification (rejectUnauthorized: false)'
+        required: false
         default: 'false'
 outputs:
     response:
-        description: 'HTTP Response Content'
+        description: 'HTTP Response Body as JSON string'
     headers:
         description: 'HTTP Response Headers'
     status:
-        description: 'HTTP status message'
+        description: 'HTTP Response Status Code'
+    requestError:
+        description: 'On request failure, a JSON string with fields: name, message, code, status'
 runs:
     using: 'node24'
     main: 'dist/index.js'


### PR DESCRIPTION
## Summary
Fixes inaccuracies in `action.yml` and the README Response table. No behaviour changes — documentation only.

## Changes
### **`action.yml` — inputs:**
 - `contentType`: added missing `default: 'application/json'` (the code always falls back to this value)
 - `retry`: added missing `default: '0'` (code initialises `let retry = 0`)
 - `retryWait`: added missing `default: '3000'` (code initialises `let retryWait = 3000`)
 - `preventFailureOnNoResponse`: added missing `default: 'false'`; fixed grammar ("respond without an response")
 - `escapeData`: added missing `default: 'false'`
 - `ignoreSsl`: added missing `required: false`
 - `files`, `file`, `customHeaders`, `ignoreStatusCodes`: tightened descriptions to reflect actual format/behaviour
 
### **`action.yml` — outputs:**
 - `status`: corrected description from "HTTP status message" to "HTTP Response Status Code" (the value is `response.status`, a number)
 - `response`: corrected description from "HTTP Response Content" to "HTTP Response Body as JSON string"
 - `requestError`: **added** — this output is set by `httpClient.js` on Axios errors (`{ name, message, code, status }`) but was entirely absent from the action metadata
 
### **`README.md`:**
 - Corrected `status` row to match `action.yml`
 - Added `requestError` row to the Response table

## Motivation
Several inputs had no documented defaults, causing consumers to be unaware of the values the action uses when those inputs are omitted. The `requestError` output was silently produced by the code but invisible to users reading the action metadata or README, making error-handling workflows impossible to discover. The `status` description 
was factually wrong (a numeric code, not a message string).

## Impact
 - **Consumers:** No breaking changes. All existing workflows continue to work unchanged.
 - **New users:** Can now discover `requestError` and use it in `if:` conditions or subsequent steps for error handling.
 - **Tooling:** GitHub's action editor and schema validators will now surface correct defaults for `contentType`, `retry`, `retryWait`, `preventFailureOnNoResponse`, and `escapeData`.

## Testing
Documentation-only change. Verified by diffing the updated values against the source code in `src/index.js` and `src/httpClient.js`.

## Notes
Two code-level issues were identified but are out of scope for this PR:
 - When `httpsCA`/`httpsCert` are set, the new `https.Agent` does not inherit the `ignoreSsl` flag
 - Numeric inputs (`retry`, `timeout`, `retryWait`) have no validation and silently produce `NaN` on non-numeric input
