### PR TITLE
docs(readme): update redirecting GitHub Docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Additional information is available if debug logging is enabled:
 - Instance Configuration (Url / Timeout / Headers)
 - Request Data (Body / Auth / Method)
 
-To [enable debug logging in GitHub Actions](https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging) create a secret `ACTIONS_RUNNER_DEBUG` with a value of `true`
+To [enable debug logging in GitHub Actions](https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging), create a secret `ACTIONS_RUNNER_DEBUG` with a value of `true`.
 
 ### Local Usage
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
 `headers` | Headers
 `status` | HTTP status message
 
-To display HTTP response data in the GitHub Actions log give the request an `id` and access its `outputs`. You can also access specific field from the response data using [fromJson()](https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson) expression.
+To display HTTP response data in the GitHub Actions log give the request an `id` and access its `outputs`. You can also access specific field from the response data using [fromJson()](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#fromjson) expression.
 
 ```yaml
 steps:
@@ -81,7 +81,7 @@ Additional information is available if debug logging is enabled:
 - Instance Configuration (Url / Timeout / Headers)
 - Request Data (Body / Auth / Method)
 
-To [enable debug logging in GitHub Actions](https://docs.github.com/en/actions/managing-workflow-runs/enabling-debug-logging) create a secret `ACTIONS_RUNNER_DEBUG` with a value of `true`
+To [enable debug logging in GitHub Actions](https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging) create a secret `ACTIONS_RUNNER_DEBUG` with a value of `true`
 
 #### Local Usage
 


### PR DESCRIPTION
## Summary
Updates two GitHub Docs hyperlinks in `README.md` that were returning
HTTP 301 redirects to their current canonical URLs.

## Changes
- `learn-github-actions/expressions#fromjson` → `reference/workflows-and-actions/expressions#fromjson`
- `managing-workflow-runs/enabling-debug-logging` → `how-tos/monitor-workflows/enable-debug-logging`

## Motivation
GitHub reorganised its documentation URL structure. The old paths issue permanent 301 redirects, which can silently break in link-checkers, offline readers, and tools that do not follow redirects. Updating to the canonical paths ensures readers reach the correct page directly.

## Impact
- Affects readers clicking links in `README.md` — no functional or behavioral change to the action itself.
- Fully backward-compatible; no API, inputs, or outputs are touched.

## Testing
Verified with `curl -sI` that:
- The old URLs return `HTTP/2 301`.
- The new URLs return `HTTP/2 200`.

## Notes
`RELEASE.md` was checked and contains no broken or redirecting links.